### PR TITLE
Fix Dropdown Issue in relabel

### DIFF
--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/components/CapturePhoto/CapturePhotos.tsx
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/components/CapturePhoto/CapturePhotos.tsx
@@ -38,9 +38,12 @@ const CameraSelector = ({ selectedCamera, setSelectedCamera }): JSX.Element => {
   }));
 
   const onDropdownChange = (_, data): void => {
-    const { key } = data.value.content;
-    const newSelectedCamera = availableCameras.find((ele) => ele.id === key);
-    if (newSelectedCamera) setSelectedCamera(newSelectedCamera);
+    if (data.value === null) setSelectedCamera((prev) => prev);
+    else {
+      const { key } = data.value.content;
+      const newSelectedCamera = availableCameras.find((ele) => ele.id === key);
+      if (newSelectedCamera) setSelectedCamera(newSelectedCamera);
+    }
   };
 
   return (

--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/CameraDetails.tsx
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/CameraDetails.tsx
@@ -18,7 +18,7 @@ const CameraDetails: FC = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(thunkGetProject());
-  }, []);
+  }, [dispatch]);
 
   if (!camera) return <Redirect to="/cameras" />;
 

--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/LabelingPage.tsx
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/LabelingPage.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Flex, Button, Text, ChevronStartIcon, ChevronEndIcon } from '@fluentui/react-northstar';
 
 import Scene from '../components/LabelingPage/Scene';
-import { LabelingType, Annotation, BoxLabel } from '../store/labelingPage/labelingPageTypes';
+import { LabelingType, Annotation } from '../store/labelingPage/labelingPageTypes';
 import { State } from '../store/State';
 import { LabelImage } from '../store/image/imageTypes';
 import { getAnnotations, resetAnnotation } from '../store/labelingPage/labelingPageActions';

--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/ManualIdentification.tsx
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/ManualIdentification.tsx
@@ -91,6 +91,8 @@ const ManualIdentification: FC = () => {
     dispatch(getLabelImages());
   }, [dispatch]);
 
+  const selectedPartValue = partItems.find((e) => (e.content as any).key === selectedPartId);
+
   return (
     <div>
       <Text size="larger" weight="semibold">
@@ -101,7 +103,11 @@ const ManualIdentification: FC = () => {
         <Grid columns="3" styles={{ columnGap: '1em', justifyItems: 'center' }}>
           <Flex vAlign="center" gap="gap.smaller">
             <Text truncated>Select Part:</Text>
-            <Dropdown items={partItems} onChange={onDropdownChange} />
+            <Dropdown
+              items={partItems}
+              onChange={onDropdownChange}
+              value={selectedPartValue ? { ...selectedPartValue } : null}
+            />
           </Flex>
           <Flex vAlign="center" gap="gap.smaller" styles={{ width: '80%' }}>
             <Text>Confidence Level:</Text>

--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/ManualIdentification.tsx
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/ManualIdentification.tsx
@@ -81,9 +81,13 @@ const ManualIdentification: FC = () => {
     return filteredImages;
   }, [confidenceLevelRange, ascend, images, selectedPartId]);
 
-  const onDropdownChange = (_, data): void => {
-    const { key } = data.value.content;
-    setSelectedPartId(key);
+  const onDropdownChange = (_, { value }): void => {
+    if (value === null) {
+      setSelectedPartId((prev) => prev);
+    } else {
+      const { key } = value.content;
+      setSelectedPartId(key);
+    }
   };
 
   useEffect(() => {
@@ -103,11 +107,7 @@ const ManualIdentification: FC = () => {
         <Grid columns="3" styles={{ columnGap: '1em', justifyItems: 'center' }}>
           <Flex vAlign="center" gap="gap.smaller">
             <Text truncated>Select Part:</Text>
-            <Dropdown
-              items={partItems}
-              onChange={onDropdownChange}
-              value={selectedPartValue ? { ...selectedPartValue } : null}
-            />
+            <Dropdown items={partItems} onChange={onDropdownChange} value={selectedPartValue} />
           </Flex>
           <Flex vAlign="center" gap="gap.smaller" styles={{ width: '80%' }}>
             <Text>Confidence Level:</Text>

--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/PartIdentification.tsx
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/pages/PartIdentification.tsx
@@ -212,7 +212,8 @@ function useDropdownItems<T>(
 
 const ModuleSelector = ({ moduleName, to, value, setSelectedModuleItem, items, isMultiple }): JSX.Element => {
   const onDropdownChange = (_, data): void => {
-    if (Array.isArray(data.value)) {
+    if (data.value === null) setSelectedModuleItem((prev) => prev);
+    else if (Array.isArray(data.value)) {
       const ids = data.value.map((ele) => ele.content.key);
       setSelectedModuleItem(ids);
     } else {

--- a/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/store/project/projectReducer.ts
+++ b/VisionOnEdge/EdgeSolution/modules/WebModule/ui/src/store/project/projectReducer.ts
@@ -58,8 +58,6 @@ const projectReducer = (state = initialState.project, action: ProjectActionTypes
     case GET_TRAINING_STATUS_REQUEST:
       return {
         ...state,
-        // if trainingStatus is ok originally, set it to 'not yet training' and get the exportin status from server again
-        trainingStatus: state.trainingStatus === '' ? 'not yet training' : state.trainingStatus,
       };
     case GET_TRAINING_STATUS_SUCCESS: {
       const { successRate, modelUrl, successfulInferences, unIdetifiedItems } = action.payload;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Issue: In relabel page, the page turns blank with error: `Cannot read property 'content' of null` sometimes.
* Root cause:
1. If we control `Dropdown` by ourselves, we should provide the prop `value`
2. The prop `value` should be a new object every time (not sure why. Looks like a bug in fluent).

