### PR TITLE
Refactor/images project import error

### DIFF
--- a/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/azure_training/signals.py
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/azure_training/signals.py
@@ -103,7 +103,8 @@ def azure_project_is_configured_handler(**kwargs):
         logger.info("Nothing to do")
         return
     instance = kwargs['instance']
-    if instance.has_configured:
+    if instance.has_configured and instance.has_configured != Project.objects.get(
+            pk=instance.id).has_configured:
         for other_project in Project.objects.exclude(id=instance.id):
             other_project.has_configured = False
             other_project.save()

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/models.py
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/models.py
@@ -1,11 +1,9 @@
 """
 Models for Azure CustomVision images
 """
-import datetime
+
 import json
 import logging
-import threading
-import time
 from io import BytesIO
 
 import requests
@@ -15,6 +13,8 @@ from django.db.models.signals import pre_delete, pre_save
 from PIL import Image as PILImage
 from rest_framework import status
 
+from vision_on_edge.azure_training.models import Project
+
 from ..azure_parts.models import Part
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 class Image(models.Model):
-    """Image Model"""
+    """Image.
+
+    models.Model
+    """
 
     image = models.ImageField(upload_to="images/")
     part = models.ForeignKey(Part, on_delete=models.CASCADE)
@@ -31,26 +34,28 @@ class Image(models.Model):
     is_relabel = models.BooleanField(default=False)
     confidence = models.FloatField(default=0.0)
     uploaded = models.BooleanField(default=False)
-    project = models.ForeignKey("azure_training.Project",
-                                on_delete=models.CASCADE,
-                                null=True)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE, null=True)
     customvision_id = models.CharField(max_length=1000, null=True, blank=True)
     remote_url = models.CharField(max_length=1000, null=True)
 
     def get_remote_image(self):
-        """Download image using remote url"""
+        """get_remote_image.
+
+        Download image using remote url
+        """
+
         try:
             if self.remote_url:
                 resp = requests.get(self.remote_url)
                 if resp.status_code != status.HTTP_200_OK:
                     raise requests.exceptions.RequestException
-                fp = BytesIO()
-                fp.write(resp.content)
+                bytes_io = BytesIO()
+                bytes_io.write(resp.content)
                 file_name = f"{self.part.name}-{self.remote_url.split('/')[-1]}"
                 logger.info("Saving as name %s", file_name)
 
-                self.image.save(file_name, files.File(fp))
-                fp.close()
+                self.image.save(file_name, files.File(bytes_io))
+                bytes_io.close()
                 self.save()
         except requests.exceptions.RequestException as request_err:
             # Probably wrong url
@@ -60,7 +65,14 @@ class Image(models.Model):
             raise unexpected_error
 
     def set_labels(self, left: float, top: float, width: float, height: float):
-        "Set label to image"
+        """set_labels.
+
+        Args:
+            left (float): left
+            top (float): top
+            width (float): width
+            height (float): height
+        """
         try:
             if left > 1 or top > 1 or width > 1 or height > 1:
                 raise ValueError(
@@ -71,11 +83,11 @@ class Image(models.Model):
                 logger.error("%s, %s, %s, %s must be greater than 0", left,
                              top, width, height)
                 return
-            elif left + width > 1:
+            if left + width > 1:
                 logger.error("left + width: %s + %s must be less than 1", left,
                              width)
                 return
-            elif top + height > 1:
+            if top + height > 1:
                 logger.error("top + height: %s + %s must be less than 1", top,
                              height)
                 return
@@ -102,28 +114,39 @@ class Image(models.Model):
             raise uncaught_err
 
     def add_labels(self, left: float, top: float, width: float, height: float):
-        "Add Labels to Image"
+        """add_labels.
+
+        Args:
+            left (float): left
+            top (float): top
+            width (float): width
+            height (float): height
+        """
         try:
             if left > 1 or top > 1 or width > 1 or height > 1:
-                raise ValueError("%s, %s, %s, %s must be less than 1", left,
-                                 top, width, height)
+                raise ValueError("%s, %s, %s, %s must be less than 1" %
+                                 (left, top, width, height))
             if left < 0 or top < 0 or width < 0 or height < 0:
-                raise ValueError("%s, %s, %s, %s must be greater than 0", left,
-                                 top, width, height)
+                raise ValueError("%s, %s, %s, %s must be greater than 0" %
+                                 (left, top, width, height))
             if left + width > 1:
-                raise ValueError("left + width: %s + %s must be less than 1",
-                                 left, width)
+                raise ValueError("left + width: %s + %s must be less than 1" %
+                                 (left, width))
             if top + height > 1:
-                raise ValueError("top + height: %s + %s  must be less than 1",
-                                 top, height)
+                raise ValueError("top + height: %s + %s  must be less than 1" %
+                                 (top, height))
         except ValueError as value_err:
             raise value_err
 
     @staticmethod
-    def pre_save(instance, update_fields, **kwargs):
-        """Image pre_save
-        Delete Image on Custom Vision
+    def pre_save(instance, **kwargs):
+        """pre_save.
+
+        Args:
+            instance:
+            kwargs:
         """
+
         if 'instance' not in kwargs:
             return
         instance = kwargs['instance']
@@ -131,9 +154,15 @@ class Image(models.Model):
             return
 
     @staticmethod
-    def pre_delete(sender, **kwargs):
-        """Image pre_delete
+    def pre_delete(**kwargs):
+        """pre_delete.
+
+        Args:
+            kwargs:
         """
+
+        if 'sender' not in kwargs or kwargs['sender'] is not Image:
+            return
         if 'instance' not in kwargs:
             return
         instance = kwargs['instance']

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/signals.py
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/signals.py
@@ -42,6 +42,7 @@ def relabel_setting_change_handler(**kwargs):
         logger.info("Nothing to do")
         return
     old_project = Project.objects.get(pk=instance.id)
+
     if old_project.accuracyRangeMin == instance.accuracyRangeMin and \
             old_project.accuracyRangeMax == instance.accuracyRangeMax:
         logger.info(
@@ -50,5 +51,7 @@ def relabel_setting_change_handler(**kwargs):
         return
 
     logger.info("Project accuracyRangeMin and accuracyRangeMax changed...")
-    logger.info("Deleting all relabel project....")
-    Image.objects.filter(project=kwargs['instance'], is_relabel=True).delete()
+    logger.info("Deleting all relabel images...")
+    logger.info("Project id: %s", instance.id)
+    Image.objects.filter(project=instance, is_relabel=True).delete()
+    logger.info("Deleting all relabel images... complete")

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/signals.py
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/signals.py
@@ -4,7 +4,7 @@ Signals
 
 import logging
 
-from django.db.models.signals import post_save, pre_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
 from ..azure_training.models import Project

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/tests/test_signals.py
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/images/tests/test_signals.py
@@ -69,7 +69,7 @@ class ImageSignalsTestCase(APITransactionTestCase):
         for setting_name in ["valid_setting", "invalid_setting"]:
             project_obj = Project.objects.get(setting__name=setting_name)
 
-            for i in range(40):
+            for _ in range(40):
                 Image.objects.create(project=project_obj,
                                      part=Part.objects.first(),
                                      is_relabel=True)
@@ -96,7 +96,7 @@ class ImageSignalsTestCase(APITransactionTestCase):
         for setting_name in ["valid_setting", "invalid_setting"]:
             project_obj = Project.objects.get(setting__name=setting_name)
 
-            for i in range(40):
+            for _ in range(40):
                 Image.objects.create(project=project_obj,
                                      part=Part.objects.first(),
                                      is_relabel=True)
@@ -123,7 +123,7 @@ class ImageSignalsTestCase(APITransactionTestCase):
         for setting_name in ["valid_setting", "invalid_setting"]:
             project_obj = Project.objects.get(setting__name=setting_name)
 
-            for i in range(40):
+            for _ in range(40):
                 Image.objects.create(project=project_obj,
                                      part=Part.objects.first(),
                                      is_relabel=True)
@@ -150,7 +150,7 @@ class ImageSignalsTestCase(APITransactionTestCase):
         for setting_name in ["valid_setting", "invalid_setting"]:
             project_obj = Project.objects.get(setting__name=setting_name)
 
-            for i in range(40):
+            for _ in range(40):
                 Image.objects.create(project=project_obj,
                                      part=Part.objects.first(),
                                      is_relabel=True)


### PR DESCRIPTION
## Purpose
* Refactor/images project import error to make pylint pass
* Fix a bug when update relabel params will trigger other project to post relabel param to inference.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
```
python manage.py test
```

## What to Check
Verify that the following are valid
* All relabel image should be deleted
* pylint vision_on_edge/images/models no error

## Other Information
N/A