### PR TITLE
Fix pull_cv_project store wrong customvision_project_name in db

### DIFF
--- a/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/azure_training/api/views.py
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/backend/vision_on_edge/azure_training/api/views.py
@@ -734,11 +734,13 @@ def pull_cv_project(request, project_id):
 
     try:
         # Invalid CustomVision Project ID handled by exception
-        trainer.get_project(project_id=customvision_project_id)
-
+        project_obj.customvision_project_name = trainer.get_project(
+            project_id=customvision_project_id).name
         project_obj.customvision_project_id = customvision_project_id
         project_obj.deployed = False
-        update_fields.extend(["customvision_project_id", "deployed"])
+        update_fields.extend([
+            "customvision_project_name", "customvision_project_id", "deployed"
+        ])
 
         logger.info("Deleting all parts and images...")
         Part.objects.filter(is_demo=False).delete()


### PR DESCRIPTION
## Purpose
* Fix pull_cv_project store wrong customvision_project_name in db

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
```
python manage.py test
```

## What to Check
Verify that the following are valid
* localhost:8000/api/projects name is correct

## Other Information
N/A