### PR TITLE
Fix Retraining Logic for Demo Project

### DIFF
--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui_v2/src/components/ConfigTaskPanel.tsx
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui_v2/src/components/ConfigTaskPanel.tsx
@@ -96,7 +96,6 @@ export const ConfigTaskPanel: React.FC<ConfigTaskPanelProps> = ({
     state.trainingProject.nonDemo.includes(projectData.trainingProject),
   );
   const scenarios = useSelector((state: State) => state.scenario);
-  const demoProject = useSelector((state: State) => state.trainingProject.isDemo);
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -104,7 +103,6 @@ export const ConfigTaskPanel: React.FC<ConfigTaskPanelProps> = ({
     const cloneProject = R.clone(projectData);
     (cloneProject as any)[key] = value;
     if (key === 'trainingProject') {
-      if (!demoProject.includes(cloneProject.trainingProject)) cloneProject.needRetraining = false;
       cloneProject.parts = [];
       cloneProject.cameras = [];
 

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui_v2/src/store/__test__/project.spec.ts
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui_v2/src/store/__test__/project.spec.ts
@@ -1,0 +1,46 @@
+import mockAxios from 'axios';
+import { thunkPostProject } from '../project/projectActions';
+import { initialProjectData } from '../project/projectReducer';
+
+jest.mock('axios', () => {
+  return jest.fn().mockResolvedValue({});
+});
+
+const mockDispatch = jest.fn();
+const mockState = {
+  project: {
+    data: initialProjectData,
+  },
+  trainingProject: {
+    isDemo: [1],
+  },
+};
+const mockGetState = () => mockState;
+const mockProjectData = { ...initialProjectData, trainingProject: 1 };
+
+describe('Post project', () => {
+  it('needRetraining should be false when the trainingProject is demo', () => {
+    thunkPostProject(mockProjectData)(mockDispatch, mockGetState as any, undefined);
+    expect((mockAxios as any).mock.calls[0][1]).toStrictEqual({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: {
+        parts: initialProjectData.parts,
+        cameras: initialProjectData.cameras,
+        project: 1,
+        needRetraining: false,
+        accuracyRangeMin: initialProjectData.accuracyRangeMin,
+        accuracyRangeMax: initialProjectData.accuracyRangeMax,
+        maxImages: initialProjectData.maxImages,
+        metrics_is_send_iothub: initialProjectData.sendMessageToCloud,
+        metrics_frame_per_minutes: initialProjectData.framesPerMin,
+        name: initialProjectData.name,
+        send_video_to_cloud: initialProjectData.sendVideoToCloud,
+        inference_mode: initialProjectData.inferenceMode,
+        fps: 10,
+      },
+    });
+  });
+});

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui_v2/src/store/project/projectActions.ts
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui_v2/src/store/project/projectActions.ts
@@ -229,6 +229,7 @@ export const thunkPostProject = (projectData: Omit<ProjectData, 'id'>): ProjectT
   const projectId = getState().project.data.id;
   const isProjectEmpty = projectId === null || projectId === undefined;
   const url = isProjectEmpty ? `/api/part_detections/` : `/api/part_detections/${projectId}/`;
+  const isDemo = getState().trainingProject.isDemo.includes(projectData.trainingProject);
 
   dispatch(postProjectRequest(false));
 
@@ -237,7 +238,7 @@ export const thunkPostProject = (projectData: Omit<ProjectData, 'id'>): ProjectT
       parts: projectData.parts,
       cameras: projectData.cameras,
       project: projectData.trainingProject,
-      needRetraining: projectData.needRetraining,
+      needRetraining: isDemo ? false : projectData.needRetraining,
       accuracyRangeMin: projectData.accuracyRangeMin,
       accuracyRangeMax: projectData.accuracyRangeMax,
       maxImages: projectData.maxImages,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Force the `needRetraining` to be false when post part_detection. And add a test case for this.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test
*  Get the code

```bash
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```bash
yarn test
```