### PR TITLE
Refactor the process of calling  `re_label_keep_alive`

### DIFF
--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/components/Deployment/Deployment.tsx
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/components/Deployment/Deployment.tsx
@@ -89,7 +89,7 @@ export const Deployment: React.FC = () => {
     dispatch(getTrainingProject(true));
     // The property `upload` would be changed after configure
     // Re fetch the images to get the latest data
-    dispatch(getImages());
+    dispatch(getImages({ freezeRelabelImgs: false }));
   }, [dispatch]);
 
   const changeProbThreshold = (newValue: number) => dispatch(updateProjectData({ probThreshold: newValue }));
@@ -236,7 +236,7 @@ const UpdateModelInstruction = ({ newImagesCount, updateModel }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(getImages());
+    dispatch(getImages({ freezeRelabelImgs: false }));
   }, [dispatch]);
 
   if (newImagesCount)

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/pages/Home.tsx
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/pages/Home.tsx
@@ -23,7 +23,7 @@ export const Home: React.FC = () => {
     (async () => {
       setLoading(true);
       await dispatch(getCameras(false));
-      await dispatch(getImages());
+      await dispatch(getImages({ freezeRelabelImgs: false }));
       await dispatch(thunkGetProject());
       setLoading(false);
     })();

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/pages/Images.tsx
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/pages/Images.tsx
@@ -112,7 +112,6 @@ export const Images: React.FC = () => {
     (state: State) =>
       selectAllImages(state).filter((e) => e.isRelabel && e.manualChecked && !e.uploaded).length,
   );
-  const nonDemoProjectId = useSelector((state: State) => state.trainingProject.nonDemo[0]);
 
   const onUpload = () => {
     fileInputRef.current.click();
@@ -180,13 +179,10 @@ export const Images: React.FC = () => {
   );
 
   useEffect(() => {
-    (async () => {
-      await Axios.post(`/api/projects/${nonDemoProjectId}/relabel_keep_alive/`);
-      dispatch(getImages());
-      // We need part info for image list items
-      dispatch(getParts());
-    })();
-  }, [dispatch, nonDemoProjectId]);
+    dispatch(getImages({ freezeRelabelImgs: true }));
+    // We need part info for image list items
+    dispatch(getParts());
+  }, [dispatch]);
 
   useKeepAlive(relabelImages.length > 0);
 

--- a/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/pages/PartDetails.tsx
+++ b/factory-ai-vision/EdgeSolution/modules/WebModule/ui/src/pages/PartDetails.tsx
@@ -184,7 +184,7 @@ export const Images: React.FC<{ labeledImages }> = ({ labeledImages }) => {
   );
 
   useEffect(() => {
-    dispatch(getImages());
+    dispatch(getImages({ freezeRelabelImgs: false }));
     // Image list items need part info
     dispatch(getParts());
   }, [dispatch]);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Previously, we may encounter a race condition of the relabel-images. The solution is by calling the `relabel_keep_alive` first, freezing the relabel-images and then call `GET /images`. The change has been done in the commit 95a04024441664e6dbb7f4ac173547de017e20a8
This pull request aims to make the code looks more readable and maintinable by moving the call to the action creator `getImages`. Please give some advice for making this logic more readable.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test
*  Get the code

```bash
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```bash
npm run test
```

## What to Check
Verify that the following are valid
* All tests shall pass.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
