### PR TITLE
Fix "Standard_NC6" not supported in Southeast Asia

### DIFF
--- a/factory-ai-vision/Deploy/arm/one-click-armdeploy.json
+++ b/factory-ai-vision/Deploy/arm/one-click-armdeploy.json
@@ -14,9 +14,9 @@
       "defaultValue": "cpu",
       "allowedValues": [
         "cpu",
-        "gpu (NVIDIA cuda11)",
-        "vpu (Movidius)",
-        "Jetson (Jetpack 4.4)"
+        "gpu",
+        "vpu",
+        "Jetson"
       ],
       "type": "string",
       "metadata": {
@@ -386,7 +386,7 @@
             "osDiskType": "Standard_LRS",
             "vmSize": {
               "cpu": "Standard_DS1_v2",
-              "gpu": "Standard_NC6"
+              "gpu": "Standard_NC6s_v3"
             },
             "subnetAddressPrefix": "10.1.0.0/24",
             "addressPrefix": "10.1.0.0/16",
@@ -602,12 +602,12 @@
               }
             },
             {
-              "name": "[concat(parameters('vmName'), parameters('moduleRuntime'))]",
+              "name": "[concat(parameters('vmName'), '-', parameters('moduleRuntime'))]",
               "type": "Microsoft.Compute/virtualMachines",
               "apiVersion": "2020-06-01",
               "location": "[parameters('location')]",
               "dependsOn": [
-                "[concat('Microsoft.Network/networkInterfaces/', variables('networkInterfaceName'))]"
+                "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
               ],
               "properties": {
                 "hardwareProfile": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Fix the error that `Standard_NC6` not supported in `Southeast Asia`, and change moduleRuntime to let it can be used in vmName

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```