### PR TITLE
fix: GPU VM cannot deploy inference and predict module

### DIFF
--- a/factory-ai-vision/Deploy/arm/one-click-armdeploy.json
+++ b/factory-ai-vision/Deploy/arm/one-click-armdeploy.json
@@ -14,9 +14,9 @@
       "defaultValue": "cpu",
       "allowedValues": [
         "cpu",
-        "gpu",
-        "vpu",
-        "Jetson"
+        "gpu (NVIDIA cuda11)",
+        "vpu (Movidius)",
+        "Jetson (Jetpack 4.4)"
       ],
       "type": "string",
       "metadata": {
@@ -147,6 +147,7 @@
       }
     },
     {
+      "condition": "[equals(parameters('videoCaptureModule'), 'lva')]",
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2019-06-01",
       "name": "[variables('storageName')]",
@@ -304,9 +305,6 @@
           "vmName": {
             "value": "visionOnEdgeVM"
           },
-          "location": {
-            "value": "[resourceGroup().location]"
-          },
           "ubuntuOSVersion": {
             "value": "18.04-LTS"
           },
@@ -343,9 +341,6 @@
           "contentVersion": "1.0.0.0",
           "parameters": {
             "vmName": {
-              "type": "string"
-            },
-            "location": {
               "type": "string"
             },
             "ubuntuOSVersion": {
@@ -386,7 +381,11 @@
             "osDiskType": "Standard_LRS",
             "vmSize": {
               "cpu": "Standard_DS1_v2",
-              "gpu": "Standard_NC6s_v3"
+              "gpu (NVIDIA cuda11)": "Standard_NC6"
+            },
+            "location": {
+              "cpu": "[resourceGroup().location]",
+              "gpu (NVIDIA cuda11)": "westus2"
             },
             "subnetAddressPrefix": "10.1.0.0/24",
             "addressPrefix": "10.1.0.0/16",
@@ -407,7 +406,7 @@
               "name": "[variables('networkInterfaceName')]",
               "type": "Microsoft.Network/networkInterfaces",
               "apiVersion": "2020-06-01",
-              "location": "[parameters('location')]",
+              "location": "[variables('location')[parameters('moduleRuntime')]]",
               "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupName'))]",
                 "[resourceId('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
@@ -437,7 +436,7 @@
               "name": "[parameters('networkSecurityGroupName')]",
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2020-06-01",
-              "location": "[parameters('location')]",
+              "location": "[variables('location')[parameters('moduleRuntime')]]",
               "properties": {
                 "securityRules": [
                   {
@@ -564,7 +563,7 @@
               "name": "[parameters('virtualNetworkName')]",
               "type": "Microsoft.Network/virtualNetworks",
               "apiVersion": "2020-06-01",
-              "location": "[parameters('location')]",
+              "location": "[variables('location')[parameters('moduleRuntime')]]",
               "properties": {
                 "addressSpace": {
                   "addressPrefixes": [
@@ -587,7 +586,7 @@
               "name": "[variables('publicIpAddressName')]",
               "type": "Microsoft.Network/publicIpAddresses",
               "apiVersion": "2020-06-01",
-              "location": "[parameters('location')]",
+              "location": "[variables('location')[parameters('moduleRuntime')]]",
               "sku": {
                 "name": "Basic",
                 "tier": "Regional"
@@ -602,10 +601,10 @@
               }
             },
             {
-              "name": "[concat(parameters('vmName'), '-', parameters('moduleRuntime'))]",
+              "name": "[concat(parameters('vmName'), '-', substring(parameters('moduleRuntime'), 0, 3))]",
               "type": "Microsoft.Compute/virtualMachines",
               "apiVersion": "2020-06-01",
-              "location": "[parameters('location')]",
+              "location": "[variables('location')[parameters('moduleRuntime')]]",
               "dependsOn": [
                 "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
               ],
@@ -641,7 +640,31 @@
                     }
                   ]
                 }
-              }
+              },
+              "resources": [
+                {
+                  "condition": "[equals(substring(parameters('moduleRuntime'), 0, 3), 'gpu')]",
+                  "name": "InstallNvidiaGpuDriverLinux",
+                  "type": "extensions",
+                  "apiVersion": "2015-06-15",
+                  "location": "[variables('location')[parameters('moduleRuntime')]]",
+                  "dependsOn": [
+                    "[resourceId('Microsoft.Compute/virtualMachines', concat(parameters('vmName'), '-', substring(parameters('moduleRuntime'), 0, 3)))]"
+                  ],
+                  "properties": {
+                    "publisher": "Microsoft.Azure.Extensions",
+                    "type": "CustomScript",
+                    "typeHandlerVersion": "2.0",
+                    "autoUpgradeMinorVersion": true,
+                    "settings": {
+                      "fileUris": [
+                        "https://raw.githubusercontent.com/kaka-lin/azure-intelligent-edge-patterns/feat/change-custom-arm-template/factory-ai-vision/Deploy/arm/scripts/install-nvidia-driver.sh"
+                      ],
+                      "commandToExecute": "[concat('./install-nvidia-driver.sh ', parameters('adminUsername'))]"
+                    }
+                  }
+                }
+              ]
             }
           ],
           "outputs": {
@@ -658,7 +681,9 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
       "name": "ResourcesDeployment",
-      "dependsOn": [ "CreateVM" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'CreateVM')]"
+      ],
       "properties": {
         "mode": "Incremental",
         "expressionEvaluationOptions": {

--- a/factory-ai-vision/Deploy/arm/scripts/install-nvidia-driver.sh
+++ b/factory-ai-vision/Deploy/arm/scripts/install-nvidia-driver.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# This script is intended as an initialization script used in azuredeploy.json
+# See documentation here: https://docs.microsoft.com/zh-tw/azure/virtual-machines/extensions/features-linux
+# Run with sudo
+# comments below:
+
+# Username as argument
+adminUser=$1
+
+WD=/home/$adminUser/
+
+# Sleep to let Ubuntu install security updates and other updates
+sleep 1m
+
+echo WD is $WD
+
+if [ ! -d $WD ]; then
+    echo $WD does not exist - aborting!!
+    exit
+else
+    cd $WD
+    echo "Working in $(pwd)" > install-log.txt
+fi
+
+# Set permissions so we can write to log
+sudo chmod ugo+rw install-log.txt
+
+
+export DEBIAN_FRONTEND=noninteractive
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Ubuntu 18.04, CUDA 11.3, cuDNN 8.2.0 and NVIDIA 465.19 drivers
+# https://github.com/kaka-lin/ML-Notes/blob/master/TensorFlow/document/nvidia.md
+# 1. remove/uninstall NVIDIA driver & CUDA
+sudo rm /etc/apt/sources.list.d/cuda*
+sudo apt remove -y --autoremove nvidia-cuda-toolkit
+sudo apt remove -y --autoremove nvidia-*
+sudo apt update
+sudo add-apt-repository -y ppa:graphics-drivers/ppa
+sudo apt update
+
+## 2. Add NVIDIA package repositories
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-repo-ubuntu1804_10.2.89-1_amd64.deb
+sudo dpkg -i cuda-repo-ubuntu1804_10.2.89-1_amd64.deb
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+sudo apt-get update
+
+wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb
+sudo apt install -y ./nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb
+sudo apt update
+
+## 3. Install NVIDIA driver
+sudo apt install -y --no-install-recommends nvidia-driver-465
+# Reboot. Check that GPUs are visible using the command: nvidia-smis
+
+## 4. Install development and runtime libraries (~4GB)
+sudo apt-get install -y --no-install-recommends \
+    cuda-11-3 \
+    libcudnn8=8.2.0.53-1+cuda11.3  \
+    libcudnn8-dev=8.2.0.53-1+cuda11.3
+
+echo 'export CUDA_HOME="/usr/local/cuda"' >> ~/.bashrc
+echo 'export PATH="$CUDA_HOME/bin:$PATH"' >> ~/.bashrc
+echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda-11.3/lib64"' >> ~/.bashrc
+source ~/.bashrc
+
+# Install nvidia-docker
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker
+
+## 1. Setting up Docker
+curl https://get.docker.com | sh \
+  && sudo systemctl --now enable docker
+
+## 2. Setup the stable repository and the GPG key:
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+   && curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - \
+   && curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+
+## 3. Setting up NVIDIA Container Toolkit
+curl -s -L https://nvidia.github.io/nvidia-container-runtime/experimental/$distribution/nvidia-container-runtime.list | sudo tee /etc/apt/sources.list.d/nvidia-container-runtime.list
+
+## 4. Install the nvidia-docker2 package (and dependencies)
+##    after updating the package listing
+sudo apt-get update
+sudo apt-get install -y nvidia-docker2
+sudo systemctl restart docker


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Fix the issue that `NVIDIA GPU-backed VM` cannot deploy inference module and predict module

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```